### PR TITLE
Unit testing and some refactoring across module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,18 @@
+import pytest
+import os
+import time
 
 pytest_plugins = "tests.fixtures"
 
-# import pytest
-# def pytest_collection_modifyitems(config, items):
-#     for item in items:
-#         if "apps" in item.fspath.strpath:
-#             item.add_marker(pytest.mark.apps)
+def pytest_addoption(parser):
+    parser.addoption("--seed", action="store", default=None, help="Seed for random number generators")
+    
+@pytest.fixture(scope="session")
+def GLOBAL_SEED(pytestconfig):
+    seed_value = pytestconfig.getoption("seed")
+    if seed_value is not None:
+        seed_value = int(seed_value)
+    else:
+        seed_value = int(time.time()) ^ (os.getpid() << 16) & 2**32-1
+    print(f"Using seed: {seed_value}")
+    return seed_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+
+pytest_plugins = "tests.fixtures"
+
+# import pytest
+# def pytest_collection_modifyitems(config, items):
+#     for item in items:
+#         if "apps" in item.fspath.strpath:
+#             item.add_marker(pytest.mark.apps)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,15 +6,14 @@ import numpy as np
 import pytest
 import torch
 from photonlib import PhotonLib
-
-GLOBAL_SEED = 123
+from tests.conftest import GLOBAL_SEED
 
 @pytest.fixture
-def rng():
+def rng(GLOBAL_SEED):
     return  np.random.default_rng(GLOBAL_SEED)
 
 @pytest.fixture
-def torch_rng():
+def torch_rng(GLOBAL_SEED):
     return torch.Generator().manual_seed(GLOBAL_SEED)
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,68 @@
+import os
+from tempfile import NamedTemporaryFile
+
+import h5py
+import numpy as np
+import pytest
+import torch
+from photonlib import PhotonLib
+
+GLOBAL_SEED = 123
+
+@pytest.fixture
+def rng():
+    return  np.random.default_rng(GLOBAL_SEED)
+
+@pytest.fixture
+def torch_rng():
+    return torch.Generator().manual_seed(GLOBAL_SEED)
+
+
+
+@pytest.fixture
+def num_pmt():
+    """can't change because of hardcoded values in the SIREN model"""
+    return 180
+
+def writable_temp_file(suffix=None):
+    return NamedTemporaryFile('w', suffix=suffix, delete=False).name
+
+@pytest.fixture
+def fake_photon_library_ranges():
+    return [[-400, -35], 
+            [-200, 170],
+            [-1000, 1000]]
+    
+@pytest.fixture
+def fake_photon_library_shape():
+    return (10, 25, 30)
+
+@pytest.fixture
+def fake_photon_library(rng, num_pmt, fake_photon_library_ranges, fake_photon_library_shape):
+    """
+    h5 file has the following structure:
+       - numvox: number of voxels in each dimension with shape (3,)
+       - vis: 3D array of visibility values with shape (numvox, Npmt)
+       - min: minimum coordinate of the active volume with shape (3,)
+       - max: maximum coordinate of the active volume with shape (3,)
+    """
+    fake_h5 = writable_temp_file(suffix='.h5')
+    with h5py.File(fake_h5, 'w') as f:
+        f.create_dataset('numvox', shape=(3,), data=fake_photon_library_shape)
+        total_numvox = np.prod(f['numvox'][:])
+
+        # fake vis data -- random numbers uniformly distributed from 10^-7 to 10^-3
+        vis = 10**rng.uniform(low=-7, high=-3, size=(total_numvox, num_pmt))
+        f.create_dataset('vis', shape=(total_numvox, num_pmt), data=vis)
+        
+        # fake min/max data
+        mins, maxs = np.array(fake_photon_library_ranges).T
+        
+        f.create_dataset('min', shape=(3,), data=mins)
+        f.create_dataset('max', shape=(3,), data=maxs)
+    yield fake_h5
+    os.remove(fake_h5)
+
+@pytest.fixture
+def plib(fake_photon_library):
+    return PhotonLib.load(fake_photon_library)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+python_files = test_*.py
+; markers =
+;     apps: mark a test as a test for apps submodule (which is slow)
+;     serial

--- a/tests/test_AABox.py
+++ b/tests/test_AABox.py
@@ -1,0 +1,70 @@
+import pytest
+import torch
+import numpy as np
+
+from photonlib.meta import AABox
+from tests.fixtures import fake_photon_library
+
+
+@pytest.fixture
+def ranges():
+    return [[0, 1], 
+            [0, 2],
+            [0, 3]]
+
+@pytest.fixture
+def aabox(ranges):
+    return AABox(ranges)
+
+def test_AABox_init(aabox, ranges, fake_photon_library):
+    # test already done by fixture
+    assert torch.allclose(aabox.lengths, torch.tensor([1,2,3], dtype=torch.float32))
+    assert torch.allclose(aabox.ranges, torch.as_tensor(ranges, dtype=torch.float32))
+    
+    # test with wrong shape
+    with pytest.raises(ValueError):
+        AABox(torch.zeros(2,3))
+    with pytest.raises(ValueError):
+        AABox(torch.zeros(4))
+        
+    # test init with numpy array
+    a = AABox(np.array(ranges))
+    assert len(a.ranges.shape) == 2 and a.ranges.shape[1] == 2
+    
+    # test init with torch tensor
+    a =AABox(torch.as_tensor(ranges))
+    assert len(a.ranges.shape) == 2 and a.ranges.shape[1] == 2
+    
+    # test init from photon library h5 file
+    a = AABox.load(fake_photon_library)
+    assert len(a.ranges.shape) == 2 and a.ranges.shape[1] == 2
+    
+    # test init from cfg
+    cfg = dict(photonlib=dict(filepath=fake_photon_library))
+    a = AABox.load(cfg)
+    assert len(a.ranges.shape) == 2 and a.ranges.shape[1] == 2
+    
+    # test init fail
+    with pytest.raises(TypeError):
+        AABox.load(1)
+    
+    
+def test_AABox_properties(aabox, ranges):
+    assert np.allclose(aabox.x.cpu().numpy(),ranges[0])
+    assert np.allclose(aabox.y.cpu().numpy(),ranges[1])
+    assert np.allclose(aabox.z.cpu().numpy(),ranges[2])
+    
+def test_AABox_norm_coord(aabox, ranges):
+    trange = torch.as_tensor(ranges)
+    
+    pos = torch.diff(trange).ravel()/2 # center of the box
+    norm_pos = aabox.norm_coord(pos)
+    assert torch.allclose(norm_pos, torch.zeros(3))
+    
+    pos = trange[:,0]                  # close edge
+    norm_pos = aabox.norm_coord(pos)
+    assert torch.allclose(norm_pos, -torch.ones(3))
+    
+    pos = trange[:,1]                  # far edge
+    norm_pos = aabox.norm_coord(pos)
+    assert torch.allclose(norm_pos, +torch.ones(3))

--- a/tests/test_PhotonLib.py
+++ b/tests/test_PhotonLib.py
@@ -1,0 +1,173 @@
+from photonlib import PhotonLib
+from photonlib import VoxelMeta
+import pytest
+import h5py
+import numpy as np
+import torch
+
+
+from tests.fixtures import fake_photon_library, writable_temp_file, plib, fake_photon_library_shape, fake_photon_library_ranges, num_pmt
+
+@pytest.fixture()
+def shapes(fake_photon_library_shape):
+    return fake_photon_library_shape
+
+@pytest.fixture()
+def ranges(fake_photon_library_ranges):
+    return fake_photon_library_ranges
+
+@pytest.fixture()
+def plib_with_eff(rng, fake_photon_library, shapes, ranges):
+    with h5py.File(fake_photon_library, 'r') as f:
+        vis = f['vis'][:]
+    meta = VoxelMeta.load(fake_photon_library)
+    rand_eff = rng.random()
+    return PhotonLib(meta, vis, eff=rand_eff)
+
+   
+def test_PhotonLib_init(fake_photon_library, rng):
+    # init with constructor
+    with h5py.File(fake_photon_library, 'r') as f:
+        vis = f['vis'][:]
+    meta = VoxelMeta.load(fake_photon_library)
+    rand_eff = rng.random()
+    plib = PhotonLib(meta, vis, eff=rand_eff)
+    assert np.allclose(plib.vis, vis), 'PhotonLib.__init__ does not load visibility correctly'
+    assert plib.eff == rand_eff, 'PhotonLib.__init__ does not load err correctly'
+
+    # init with PhotonLib.load(str)
+    plib = PhotonLib.load(fake_photon_library)
+    assert np.allclose(plib.vis, vis), 'PhotonLib.load does not load visibility correctly'
+    
+    # init with PhotonLib.load(dict)
+    plib = PhotonLib.load(dict(photonlib=dict(filepath=fake_photon_library)))
+    assert np.allclose(plib.vis, vis), 'PhotonLib.load does not load visibility correctly'
+    
+    # fail init with bad input
+    with pytest.raises(ValueError):
+        PhotonLib.load(123)
+        
+def test_PhotonLib_save(fake_photon_library, shapes, num_pmt, rng):
+    # save to a new file
+    with h5py.File(fake_photon_library, 'r') as f:
+        vis = f['vis'][:]
+    meta = VoxelMeta.load(fake_photon_library)
+    
+    # test for all keys except eff (numvox, min, max, vis)
+    vis_reshaped = np.swapaxes(vis.reshape(list(shapes)[::-1] + [-1]), 0, 2)
+    for vis,test in zip([vis, torch.as_tensor(vis), vis_reshaped], ["np", "torch", "np_reshaped"]):
+        new_file = writable_temp_file(suffix='.h5')
+        PhotonLib.save(new_file, vis, meta)
+        
+        with h5py.File(fake_photon_library, 'r') as f_old, h5py.File(new_file, 'r') as f_new:
+            for key in f_old.keys():
+                assert np.allclose(f_old[key][:], f_new[key][:]), f'PhotonLib.save does not save {key} correctly for {test} input'
+                
+                
+    # test for eff
+    rand_eff = rng.random()
+    new_file = writable_temp_file(suffix='.h5')
+    PhotonLib.save(new_file, vis, meta, eff=rand_eff)
+    with h5py.File(new_file, 'r') as f_new:
+        assert np.allclose(f_new['eff'], rand_eff), 'PhotonLib.save does not save eff correctly'
+
+def test_PhotonLib_view(plib, shapes, num_pmt):
+    # test vis_view, which is plib.view(plib.vis)
+    assert plib.vis_view.shape == (*shapes, num_pmt), 'PhotonLib.vis_view does not return the correct shape'
+
+
+def test_PhotonLib_visibility(plib, torch_rng, num_pmt, ranges):
+    tranges = torch.as_tensor(ranges)
+    num_pos = torch.randint(low=1, high=100, size=(1,), generator=torch_rng).item()
+    rand_pos = torch.rand(size=(num_pos, 3), generator=torch_rng)*(tranges[:,1]-tranges[:,0])+tranges[:,0]
+    
+    # test for single point and multiple points
+    for x in [rand_pos[0], rand_pos]:
+        assert plib.visibility(x).shape == (*x.shape[:-1], num_pmt)
+        
+def test_PhotonLib_len(plib, fake_photon_library):
+    with h5py.File(fake_photon_library, 'r') as f:
+        vis = f['vis'][:]
+    assert len(plib) == len(vis), 'PhotonLib.__len__ does not return the correct length'
+    
+def test_PhotonLib_n_pmts(plib, num_pmt):
+    assert plib.n_pmts == num_pmt, 'PhotonLib.n_pmts does not return the correct number of PMTs'
+    
+def test_PhotonLib_get_item(plib, fake_photon_library):
+    with h5py.File(fake_photon_library, 'r') as f:
+        vis = f['vis'][:]
+    
+    for i in range(len(vis)):
+        assert np.allclose(plib[i], vis[i]), 'PhotonLib.__getitem__ does not return the correct visibility'
+
+    with pytest.raises(IndexError):
+        plib[len(vis)]
+
+def test_PhotonLib_call(plib, plib_with_eff, torch_rng, num_pmt, ranges):
+    for plib in [plib, plib_with_eff]:    
+        tranges = torch.as_tensor(ranges)
+        num_pos = torch.randint(low=1, high=100, size=(1,), generator=torch_rng).item()
+        rand_pos = torch.rand(size=(num_pos, 3), generator=torch_rng)*(tranges[:,1]-tranges[:,0])+tranges[:,0]
+        
+        xs = [rand_pos[0], rand_pos]
+        for x in xs:
+            assert plib(x).shape == (*x.shape[:-1], num_pmt)
+            assert np.allclose(plib(x), plib.visibility(x)*plib.eff), 'PhotonLib.__call__ does not return the correct visibility'
+            
+def test_PhotonLib_gradient_on_fly(plib, torch_rng, num_pmt, shapes):
+    num_vox = np.prod(shapes)
+    rand_idx = torch.randint(low=0, high=num_vox, size=(1,), generator=torch_rng).item()
+    
+    # internal function
+    grad = plib._gradient_on_fly(rand_idx)
+    assert grad.shape == (len(shapes), num_pmt)
+    
+    # internal, multiple pts should fail
+    with pytest.raises(ValueError):
+        plib._gradient_on_fly([rand_idx]*2)
+    
+    # external function
+    grad_ext = plib.gradient_on_fly(rand_idx)
+    assert np.allclose(grad, grad_ext), 'PhotonLib.gradient_on_fly does not return the correct gradient'
+    assert grad_ext.shape == (len(shapes), num_pmt)
+    
+    # internal, multiple pts shouldn't fail
+    grad_ext = plib.gradient_on_fly(range(10))
+    assert grad_ext.shape == (10, len(shapes), num_pmt)
+    
+    # since there's no cache, gradient should be equal to gradient_on_fly
+    assert np.allclose(plib.gradient(range(10)), grad_ext), 'PhotonLib.gradient does not return the correct gradient'
+    
+    
+def test_PhotonLib_gradient_from_cache(plib, torch_rng, num_pmt, shapes, rng):
+    num_vox = np.prod(shapes)
+    
+    # without cache set, gradient_from_cache should fail
+    with pytest.raises(RuntimeError):
+        plib.gradient_from_cache(...)
+    
+    # set cache
+    random_cache = 10**torch.randint(low=-7, high=-3, size=(num_vox, len(shapes), num_pmt), generator=torch_rng, dtype=torch.float32)
+    plib.grad_cache = random_cache
+    
+    # now that it's set, plib.gradient should return the cached value
+    rand_int = torch.randint(low=0, high=num_vox, size=(100,), generator=torch_rng,)
+    
+    assert torch.allclose(plib.gradient(rand_int[0]), random_cache[rand_int[0]]), 'PhotonLib.gradient does not return the correct gradient from cache'
+
+    # multiple pts shouldn't fail
+    assert torch.allclose(plib.gradient_from_cache(rand_int), random_cache[rand_int]), 'PhotonLib.gradient_from_cache does not return the correct gradient from cache'
+    
+def test_PhotonLib_grad_view(plib, torch_rng, shapes, num_pmt):
+    
+    for axis in range(3):
+        with pytest.raises(RuntimeError):
+            plib.grad_view(axis)
+            
+    # set cache
+    num_vox = np.prod(shapes)    
+    random_cache = 10**torch.randint(low=-7, high=-3, size=(num_vox, num_pmt, len(shapes)), generator=torch_rng)
+    plib.grad_cache = random_cache
+
+    for axis in range(3):
+        plib.grad_view(axis)

--- a/tests/test_PhotonLib.py
+++ b/tests/test_PhotonLib.py
@@ -114,6 +114,7 @@ def test_PhotonLib_call(plib, plib_with_eff, torch_rng, num_pmt, ranges):
             assert plib(x).shape == (*x.shape[:-1], num_pmt)
             assert np.allclose(plib(x), plib.visibility(x)*plib.eff), 'PhotonLib.__call__ does not return the correct visibility'
             
+"""
 def test_PhotonLib_gradient_on_fly(plib, torch_rng, num_pmt, shapes):
     num_vox = np.prod(shapes)
     rand_idx = torch.randint(low=0, high=num_vox, size=(1,), generator=torch_rng).item()
@@ -171,3 +172,4 @@ def test_PhotonLib_grad_view(plib, torch_rng, shapes, num_pmt):
 
     for axis in range(3):
         plib.grad_view(axis)
+"""

--- a/tests/test_VoxelMeta.py
+++ b/tests/test_VoxelMeta.py
@@ -1,0 +1,292 @@
+import pytest
+import torch
+import numpy as np
+
+from photonlib.meta import VoxelMeta
+from tests.fixtures import fake_photon_library, fake_photon_library_ranges, fake_photon_library_shape
+
+
+@pytest.fixture
+def ranges(fake_photon_library_ranges):
+    return fake_photon_library_ranges
+    
+@pytest.fixture
+def shape(fake_photon_library_shape):
+    return fake_photon_library_shape
+
+@pytest.fixture
+def voxelmeta(shape, ranges):
+    return VoxelMeta(shape, ranges)
+
+def test_VoxelMeta_init(voxelmeta, ranges, shape, fake_photon_library):
+    # test already done by fixture
+    tranges = torch.as_tensor(ranges).float()
+    tshape = torch.as_tensor(shape).long()
+    
+    # test init from photon library h5 file
+    a = VoxelMeta.load(fake_photon_library)
+    assert torch.allclose(a.ranges, tranges), 'ranges should be the same as the h5 file'
+    assert torch.allclose(a.shape, tshape), 'shape should be the same as the h5 file'
+    
+    # test init from cfg
+    cfg = dict(photonlib=dict(filepath=fake_photon_library))
+    a = VoxelMeta.load(cfg)
+    assert torch.allclose(a.ranges, tranges), 'ranges should be the same as the h5 file'
+    assert torch.allclose(a.shape, tshape), 'shape should be the same as the h5 file'
+    
+    # fail init with bad input
+    with pytest.raises(TypeError):
+        VoxelMeta.load(1)
+
+    # test fail init with bad shape array
+    with pytest.raises(ValueError):
+        VoxelMeta((1,2,3,4), ranges)
+    
+
+def test_VoxelMeta_bins(voxelmeta, ranges, shape):
+    bins = voxelmeta.bins
+    xshape, yshape, zshape = shape
+    (xmin, xmax), (ymin, ymax), (zmin, zmax) = ranges
+    
+    assert all(np.allclose([bins[i][0], bins[i][-1]], ranges[i]) for i in range(3)), \
+        "bins should have the same range as the voxelmeta"
+    assert tuple(len(b)-1 for b in bins) == shape, "bins should have the same shape as the voxelmeta"
+    
+    # test bin centers
+    bin_centers = voxelmeta.bin_centers
+    cen = lambda x: (x[1:] + x[:-1])/2   # noqa: E731
+    expected_bin_centers = (cen(b) for b in bins)
+    assert all(torch.allclose(exp, act) for exp, act in zip(expected_bin_centers, bin_centers)), \
+                    "bin_centers should be the center of the bins"
+    
+    
+def test_VoxelMeta_len(voxelmeta):
+    assert len(voxelmeta) == voxelmeta.shape[0]*voxelmeta.shape[1]*voxelmeta.shape[2], \
+        "len(VoxelMeta) should be the product of the shape"
+    
+def test_VoxelMeta_norm_step_size(voxelmeta, shape):
+    assert torch.allclose(voxelmeta.norm_step_size,2/torch.as_tensor(shape)), \
+        "norm_step_size should be 2/shape"
+    
+    
+    """ ---------------------- axis (idx, idy, idz) inputs --------------------- """
+def test_VoxelMeta_idx_to_voxel(voxelmeta):
+    # [idx, idy, idz] -> [voxid]
+    voxaxes = [0, 0, 0]
+    tensor_vox = torch.as_tensor(voxaxes)
+    array_vox = np.array(voxaxes)
+
+    for vox in [voxaxes, tensor_vox, array_vox]:
+        voxid = voxelmeta.idx_to_voxel(vox)
+        assert isinstance(voxid, torch.Tensor), "voxid should be a torch.Tensor"
+        assert torch.allclose(voxid, torch.tensor([0])), "voxid should be [0]"
+        
+    voxaxes = [[0, 0, 0], [1, 1, 1]]
+    tensor_vox = torch.tensor(voxaxes)
+    array_vox = np.array(voxaxes)
+    
+    for vox in [voxaxes, tensor_vox, array_vox]:
+        second_answer = (1 + voxelmeta.shape[0] + voxelmeta.shape[0]*voxelmeta.shape[1]).long()
+        voxid = voxelmeta.idx_to_voxel(vox)
+        assert isinstance(voxid, torch.Tensor), "voxid should be a torch.Tensor"
+        assert torch.allclose(voxid, torch.tensor([0, second_answer])), f"voxid should be [0, {second_answer}]"
+
+def test_VoxelMeta_idx_to_coord(voxelmeta):
+    """not tested for accuracy of position, just that it returns a tensor of the right shape"""
+    
+    # [idx, idy, idz] -> [x, y, z]
+    voxaxes = [0, 0, 0]
+    tensor_vox = torch.as_tensor(voxaxes)
+    array_vox = tensor_vox.cpu().numpy()
+    
+    for vox in [voxaxes, tensor_vox, array_vox]:
+        pos = voxelmeta.idx_to_coord(vox)
+        assert isinstance(pos, torch.Tensor), "pos should be a torch.Tensor"
+        assert pos.shape == (3,), "pos should have 3 dimensions" 
+        assert (pos >= voxelmeta.ranges[:,0]).all(), "pos out of min range"
+        assert (pos <= voxelmeta.ranges[:,1]).all(), "pos out of max range"
+
+    voxaxes = [[0, 0, 0], [1, 1, 1]]
+    tensor_vox = torch.tensor(voxaxes)
+    array_vox = np.array(voxaxes)
+    for vox in [voxaxes, tensor_vox, array_vox]:
+        pos = voxelmeta.idx_to_coord(vox)
+        assert isinstance(pos, torch.Tensor), "pos should be a torch.Tensor"
+        assert pos.shape == (len(voxaxes), 3), "pos should have 3 dimensions" 
+        assert (pos >= voxelmeta.ranges[:,0]).all(), "pos out of min range"
+        assert (pos <= voxelmeta.ranges[:,1]).all(), "pos out of max range"
+
+""" ------------------------ position (x,y,z) inputs ----------------------- """
+def test_VoxelMeta_coord_to_idx(voxelmeta, torch_rng):
+    # [x, y, z] -> [voxid]
+    mins = voxelmeta.ranges[:,0]
+    maxs = voxelmeta.ranges[:,1]
+    
+    # 1D tensor
+    rand_pos = torch.rand(size=(3,), generator=torch_rng)*(maxs-mins)+mins
+    axisid = voxelmeta.coord_to_idx(rand_pos)
+    assert isinstance(axisid, torch.Tensor), "rand_pos should be a torch.Tensor"
+    assert axisid.shape == (3,), "axisid should have 3 dimensions"
+
+    # 1D list
+    axisid = voxelmeta.coord_to_idx(list(rand_pos))
+    assert isinstance(axisid, torch.Tensor), "rand_pos should be a torch.Tensor"
+    assert axisid.shape == (3,), "axisid should have 3 dimensions"
+
+    # 2D tensor
+    rand_pos = torch.rand(size=(100,3), generator=torch_rng)*(maxs-mins)+mins
+    axisid = voxelmeta.coord_to_idx(rand_pos)
+    assert isinstance(axisid, torch.Tensor), "rand_pos should be a torch.Tensor"
+    assert axisid.shape == (100, 3), "axisid should have 3 dimensions"
+    
+    # check that axisid is in the right range
+    axisid = axisid.squeeze()
+    assert torch.all(axisid >= 0)
+    assert all(torch.all(axisid[:, i] < voxelmeta.shape[i]) for i in range(3)), \
+            f"axisid should be in the right range ({voxelmeta.shape}), {axisid}"
+
+def test_VoxelMeta_coord_to_voxel(voxelmeta, torch_rng):
+    """not tested for accuracy of voxid just that the returned voxids are in range"""
+    # [x, y, z] -> [voxid]
+    mins = voxelmeta.ranges[:,0]
+    maxs = voxelmeta.ranges[:,1]
+    
+    rand_pos = torch.rand(size=(100, 3), generator=torch_rng)*(maxs-mins)+mins
+    voxids = voxelmeta.coord_to_voxel(rand_pos)    
+    
+    maxvox = voxelmeta.shape[0]*voxelmeta.shape[1]*voxelmeta.shape[2] - 1
+    assert torch.all(voxids>=0), "voxids should be positive"
+    assert torch.all(voxids<=maxvox), f"voxids should be less than {maxvox}"
+
+""" ---------------------------- voxel id inputs --------------------------- """
+def test_voxel_to_idx(voxelmeta, torch_rng):
+    # [voxid] -> [idx, idy, idz]
+    maxvox = voxelmeta.shape[0]*voxelmeta.shape[1]*voxelmeta.shape[2] - 1
+    voxids = torch.randint(0, int(maxvox), size=(100,), generator=torch_rng)
+    
+    axisid = voxelmeta.voxel_to_idx(voxids)
+    assert all(torch.all(axisid[:, i] < voxelmeta.shape[i]) for i in range(3)), \
+            f"axisid should be in the right range ({voxelmeta.shape}), {axisid}"
+
+def test_voxel_to_coord(voxelmeta, torch_rng):
+    # [voxid] -> [x, y, z], ...]
+    maxvox = voxelmeta.shape[0]*voxelmeta.shape[1]*voxelmeta.shape[2] - 1
+    voxids = torch.randint(0, int(maxvox), size=(100,), generator=torch_rng)
+
+    pos = voxelmeta.voxel_to_coord(voxids)
+
+    assert isinstance(pos, torch.Tensor), "pos should be a torch.Tensor"
+    assert pos.shape == (100, 3), "pos should have 3 dimensions" 
+    assert (pos >= voxelmeta.ranges[:,0]).all(), "pos out of min range"
+    assert (pos <= voxelmeta.ranges[:,1]).all(), "pos out of max range"
+    
+
+""" ------------------------- ring around the rosie ------------------------ """
+def test_axis2pos2axis(voxelmeta, torch_rng):
+    input = (torch.rand(size=(100, 3), generator=torch_rng)*voxelmeta.shape).long()
+    output = voxelmeta.coord_to_idx(voxelmeta.idx_to_coord(input))
+    assert torch.allclose(input, output), '(ix,iy,iz) -> (x,y,z) -> (ix,iy,iz) failed'
+
+def test_vox2axis2vox(voxelmeta, torch_rng):
+    maxvox = int(voxelmeta.shape[0]*voxelmeta.shape[1]*voxelmeta.shape[2]) - 1
+    input = torch.randint(0, maxvox, size=(100,), generator=torch_rng)
+    output = voxelmeta.idx_to_voxel(voxelmeta.voxel_to_idx(input))
+    assert torch.allclose(input, output), '(voxid) -> (ix, iy, iz) -> (voxid) failed'
+    
+    
+""" --------------------------------- other -------------------------------- """
+
+def test_VoxelMeta_select_axis(rng, voxelmeta):
+    axis = rng.integers(0, 3)
+    
+    ax, other = voxelmeta.select_axis(axis)
+    assert ax == axis, "selected axis should be the same as the input axis"
+    assert {*other} == {0,1,2} - {axis}, "other axes should be the other two axes"
+    
+    
+    ax_str = 'xyz'[axis]
+    ax, other = voxelmeta.select_axis(ax_str)
+    assert ax == axis, "selected axis should be the same as the input axis"
+    assert {*other} == {0,1,2} - {axis}, "other axes should be the other two axes"
+    
+    with pytest.raises(IndexError):
+        voxelmeta.select_axis(5)
+        
+def test_VoxelMeta_slice_shape(voxelmeta):
+    axes = [0,1,2]
+    for axis in axes:
+        other_axes = list({*axes} - {axis})
+        
+        shape = voxelmeta.slice_shape(axis)
+        assert {*shape} == {*voxelmeta.shape[other_axes].cpu().numpy()}, "shape should be the same as the voxelmeta shape without the selected axis"
+
+
+    with pytest.raises(IndexError):
+        voxelmeta.slice_shape(5)
+
+def test_VoxelMeta_check_valid_idx(voxelmeta, torch_rng, shape):
+    idx_length = torch.randint(2,100, size=(1,), generator=torch_rng).item()
+    
+    bad_idx = torch.randint(max(shape)+1, 5*max(shape), size=(idx_length,len(shape)), generator=torch_rng)    
+    assert ~voxelmeta.check_valid_idx(bad_idx).all(), "all idx should be invalid"
+    assert voxelmeta.check_valid_idx(bad_idx, return_components=True).shape == (idx_length, len(shape))
+    
+    
+    good_idx = torch.randint(0, min(shape), size=(idx_length,len(shape)), generator=torch_rng)
+    assert voxelmeta.check_valid_idx(good_idx).all(), "all idx should be valid"
+    assert voxelmeta.check_valid_idx(good_idx, return_components=True).shape == (idx_length, len(shape))
+    
+    
+def test_VoxelMeta_idx_at(voxelmeta):
+    axis = 0
+    for i in range(voxelmeta.shape[axis]):
+        idx = torch.as_tensor(voxelmeta.idx_at(axis, i))
+        assert idx.shape == (voxelmeta.shape[(axis+1)%3] * voxelmeta.shape[(axis+2)%3], 3), f"shape of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,axis] == i), f"axis {axis} of idx should be {i}"
+        assert torch.all(idx[:,(axis+1)%3] == torch.arange(voxelmeta.shape[(axis+1)%3]).repeat_interleave(voxelmeta.shape[(axis+2)%3])), f"axis {(axis+1)%3} of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,(axis+2)%3] == torch.arange(voxelmeta.shape[(axis+2)%3]).repeat(voxelmeta.shape[(axis+1)%3])), f"axis {(axis+2)%3} of idx is incorrect for axis {axis} and i {i}"
+        
+
+    axis = 1
+    for i in range(voxelmeta.shape[axis]):
+        idx = torch.as_tensor(voxelmeta.idx_at(axis, i))
+        assert idx.shape == (voxelmeta.shape[(axis+1)%3] * voxelmeta.shape[(axis+2)%3], 3), f"shape of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,axis] == i), f"axis {axis} of idx should be {i}"
+        assert torch.all(idx[:,(axis+1)%3] == torch.arange(voxelmeta.shape[(axis+1)%3]).repeat(voxelmeta.shape[(axis+2)%3])), f"axis {(axis+1)%3} of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,(axis+2)%3] == torch.arange(voxelmeta.shape[(axis+2)%3]).repeat_interleave(voxelmeta.shape[(axis+1)%3])), f"axis {(axis+2)%3} of idx is incorrect for axis {axis} and i {i}"
+        
+
+    axis = 2
+    for i in range(voxelmeta.shape[axis]):
+        idx = torch.as_tensor(voxelmeta.idx_at(axis, i))
+        assert idx.shape == (voxelmeta.shape[(axis+1)%3] * voxelmeta.shape[(axis+2)%3], 3), f"shape of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,axis] == i), f"axis {axis} of idx should be {i}"
+        assert torch.all(idx[:,(axis+1)%3] == torch.arange(voxelmeta.shape[(axis+1)%3]).repeat(voxelmeta.shape[(axis+2)%3])), f"axis {(axis+1)%3} of idx is incorrect for axis {axis} and i {i}"
+        assert torch.all(idx[:,(axis+2)%3] == torch.arange(voxelmeta.shape[(axis+2)%3]).repeat_interleave(voxelmeta.shape[(axis+1)%3])), f"axis {(axis+2)%3} of idx is incorrect for axis {axis} and i {i}"
+        
+def test_VoxelMeta_coord_at(voxelmeta):
+    # this is just a wrapper for idx_to_coord(idx_at(axis, i))
+    for axes in range(3):
+        for i in range(voxelmeta.shape[axes]):
+            coord = voxelmeta.coord_at(axes, i)
+            assert coord.shape == (voxelmeta.shape[(axes+1)%3] * voxelmeta.shape[(axes+2)%3], 3), f"shape of coord is incorrect for axis {axes} and i {i}"
+
+def test_VoxelMeta_digitize(voxelmeta, torch_rng):
+    mins = voxelmeta.ranges[0,0]
+    maxs = voxelmeta.ranges[0,1]
+    rand_pos_len = torch.randint(5, 100, size=(1,), generator=torch_rng).item()
+    
+    for axis in range(3):
+        # 1D tensor
+        rand_pos = torch.rand(size=(1,), generator=torch_rng)*(maxs-mins)+mins
+        axisid = voxelmeta.digitize(rand_pos, axis)
+        assert np.allclose(axisid, voxelmeta.coord_to_idx(rand_pos)[axis]), "axisid should be the same as the coord_to_idx for that axis"
+
+        # 1D list
+        axisid = voxelmeta.digitize(list(rand_pos), axis)
+        assert np.allclose(axisid, voxelmeta.coord_to_idx(rand_pos)[axis]), "axisid should be the same as the coord_to_idx for that axis"
+
+        # 2D tensor
+        rand_pos = torch.rand(size=(rand_pos_len,), generator=torch_rng)*(maxs-mins)+mins
+        axisid = voxelmeta.digitize(rand_pos, axis)
+        assert torch.allclose(voxelmeta.digitize(rand_pos, axis),voxelmeta.coord_to_idx(rand_pos.reshape(-1,1).repeat(1,3))[:,axis])


### PR DESCRIPTION
## Changelog:

### Testing:

Added unit tests for whole package. Coverage stats below:

| Name                                   | # Lines | Missed Lines | Cover |
|----------------------------------------|-------|------|-------|
photonlib/__init__.py        |2      |0   |100%
photonlib/meta.py          |182     |11    |94%
photonlib/photonlib.py     |104      |1    |99%
TOTAL                                                               | 288     | 12    | 96% |


### Refactoring

* making assert statments into if (...) raise (...)
* couple minor bug fixes (e.g., a method expects input of type `List` but actually a `torch.Tensor` is given
* some very light refactoring
* fix AABox's docs about ranges to follow actual usage
  * in the docs, it says ranges should be of shape (N,2) but in actuality we expect (2,N) s.t. `ranges[:,0]` are all minimum values in each dim and `range[:,1]` are all maximum values.

### Some questions:

* `meta.py` : AABox and VoxelMeta's constructors are written in mind that the number of dimensions may be 0, 1, or 2, (or more technically). But VoxelMeta's methods explicitly assume 3D vectors as inputs. Do we want to keep VoxelMeta generalized like this?
* What is `norm_step_size` in VoxelMeta's definition?
```python
class VoxelMeta(AABox):
	...
	
	@property
	def norm_step_size(self):
		return 2. / self.shape
```

* What's the expected shape of the cached gradient values? Right now, `PhotonLib.view` doesn't seem to be equipped to reconstruct the cached gradient tensor unless it's in the shape (num_dims, num_voxels, num_pmts); however, `PhotonLib`'s method calling the cached gradient, `gradient_from_cache`, expects the first dimension of the cached gradient to be of length `num_voxels`.
