### PR TITLE
Add 'lazy' loading to PhotonLib constructor and `PhotonLib.load`

### DIFF
--- a/photonlib/lazy.py
+++ b/photonlib/lazy.py
@@ -1,0 +1,86 @@
+import h5py
+import torch
+import numpy as np
+
+
+class LazyTensor:
+    """LazyTensor is a wrapper around a tensor or an h5py dataset.
+
+    It acts as a torch.Tensor but only loads the data when needed, and can be converted to a dense tensor when needed.
+    Helpful for very large datasets that don't fit in memory.
+
+    Parameters
+    ----------
+    source : torch.Tensor | h5py.File
+        The source tensor or h5py file.
+    dtype : torch.dtype, optional
+        The dtype of the tensor. Default is torch.float32.
+    device : torch.device, optional
+        The device of the tensor. Default is torch.device('cpu').
+    """
+    def __init__(self, source, dtype:torch.dtype=torch.float32, device=None):
+        self._dtype = dtype
+        self._device = torch.device(device) if device is not None else torch.device('cpu')
+
+        if isinstance(source, (h5py.Dataset,)):
+            self._src_type = 'h5py'
+            self._h5_file = source.file
+            self._h5_dataset = source
+            self._length = source.shape[0]
+        else:
+            # convert list-like to tensor
+            self._src_type = 'tensor'
+            self._tensor = torch.as_tensor(source, dtype=self._dtype)
+            if self._device.type != 'cpu':
+                self._tensor = self._tensor.to(self._device)
+            self._length = self._tensor.shape[0]
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def shape(self):
+        return self._get_source().shape
+
+    def __len__(self):
+        return self._get_source().shape[0]
+
+    def to(self, device=None):
+        if device is None or torch.device(device) == self._device:
+            return self
+        return LazyTensor(self._get_source(), self._dtype, device)
+
+    def materialize(self):
+        """load the entire data to a dense tensor on device. no-op if is a tensor"""
+        if self._src_type == 'h5py':
+            arr = self._h5_dataset[:]
+            tens = torch.as_tensor(arr, dtype=self._dtype)
+            if self._device.type != 'cpu':
+                tens = tens.to(self._device)
+            return tens
+        else:
+            return self._tensor
+
+    def _get_source(self):
+        if self._src_type == 'h5py':
+            return self._h5_dataset
+        return self._tensor
+
+    def __getitem__(self, index):
+        if self._src_type == 'h5py':
+            arr = self._h5_dataset[index]
+            tens = torch.as_tensor(arr, dtype=self._dtype)
+            if self._device.type != 'cpu':
+                tens = tens.to(self._device)
+            return tens
+        else:
+            return self._tensor[index]
+
+    def __del__(self):
+        if self._src_type == 'h5py':
+            self._h5_file.close()

--- a/photonlib/lazy.py
+++ b/photonlib/lazy.py
@@ -73,7 +73,42 @@ class LazyTensor:
 
     def __getitem__(self, index):
         if self._src_type == 'h5py':
-            arr = self._h5_dataset[index]
+            # h5py only supports advanced (fancy) indexing when indices are strictly increasing.
+            # so if random order is needed, we need to assemble them manually.
+            ds = self._h5_dataset
+
+            # scalar/slice indexing
+            if isinstance(index, (int, np.integer)) or isinstance(index, slice) or (
+                isinstance(index, tuple) and all(isinstance(i, slice) for i in index)
+            ):
+                arr = ds[index]
+                tens = torch.as_tensor(arr, dtype=self._dtype)
+                if self._device.type != 'cpu':
+                    tens = tens.to(self._device)
+                return tens
+
+            # 1D index (list, tuple, or torch.Tensor)
+            if isinstance(index, torch.Tensor):
+                if index.dtype == torch.bool:
+                    idx_list = torch.nonzero(index, as_tuple=False).flatten().cpu().tolist()
+                else:
+                    idx_list = index.flatten().cpu().tolist()
+            elif isinstance(index, np.ndarray):
+                if index.dtype == np.bool_:
+                    idx_list = np.nonzero(index)[0].tolist()
+                else:
+                    idx_list = index.flatten().tolist()
+            elif isinstance(index, (list, tuple)):
+                idx_list = list(index)
+            else:
+                arr = ds[index]
+                tens = torch.as_tensor(arr, dtype=self._dtype)
+                if self._device.type != 'cpu':
+                    tens = tens.to(self._device)
+                return tens
+
+            rows = [ds[i] for i in idx_list]
+            arr = np.stack(rows, axis=0)
             tens = torch.as_tensor(arr, dtype=self._dtype)
             if self._device.type != 'cpu':
                 tens = tens.to(self._device)

--- a/photonlib/lazy.py
+++ b/photonlib/lazy.py
@@ -11,8 +11,8 @@ class LazyTensor:
 
     Parameters
     ----------
-    source : torch.Tensor | h5py.File
-        The source tensor or h5py file.
+    source : torch.Tensor | h5py.Dataset
+        The source tensor or h5py dataset (e.g. h5py.File['vis']).
     dtype : torch.dtype, optional
         The dtype of the tensor. Default is torch.float32.
     device : torch.device, optional

--- a/photonlib/photonlib.py
+++ b/photonlib/photonlib.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import h5py
 import torch
 import numpy as np
 from scipy.ndimage import sobel
 from .meta import VoxelMeta
+from .lazy import LazyTensor
 
 class PhotonLib:
-    def __init__(self, meta: VoxelMeta, vis:torch.Tensor, eff:float = 1.):
+    def __init__(self, meta: VoxelMeta, vis:torch.Tensor | h5py.Dataset, eff:float = 1., lazy:bool = False):
         '''
         Constructor
 
@@ -17,17 +20,21 @@ class PhotonLib:
             Visibility map as 1D array indexed by the voxel IDs
         eff  : float
             Overall scaling factor for the visibility. Does not do anything if 1.0
+        lazy : bool, optional
+            Whether to load the visibility map on demand. Default is False.
         '''
         self._meta = meta
         self._eff = torch.as_tensor(eff,dtype=torch.float32)
-        self._vis = torch.as_tensor(vis,dtype=torch.float32)
+        self._vis = LazyTensor(vis,dtype=torch.float32)
+        if not lazy:
+            self._vis = self._vis.materialize()
         self.grad_cache = None
 
     def contain(self, pts):
         return self._meta.contain(pts)
     
     @classmethod
-    def load(cls, cfg_or_fname:str):
+    def load(cls, cfg_or_fname:str, lazy:bool = False):
         '''
         Constructor method that can take either a config dictionary or the data file path
 
@@ -48,16 +55,20 @@ class PhotonLib:
         meta = VoxelMeta.load(filepath)
         
         print(f'[PhotonLib] loading {filepath}')
-        with h5py.File(filepath, 'r') as f:
-            vis = torch.as_tensor(f['vis'][:])
-            eff = torch.as_tensor(f.get('eff', default=1.))
+        file = h5py.File(filepath, 'r', swmr=True, libver='latest')
+        eff = torch.as_tensor(file.get('eff', default=1.))
+        if lazy:
+            vis = file['vis']
+        else:
+            vis = file['vis'][:]
+            file.close()
         print('[PhotonLib] file loaded')
 
         #pmt_pos = None
         #if pmt_loc is not None:
         #    pmt_pos = PhotonLib.load_pmt_loc(pmt_loc)
 
-        plib = cls(meta, vis, eff)
+        plib = cls(meta, vis, eff, lazy)
 
         return plib  
 
@@ -197,7 +208,6 @@ class PhotonLib:
     def view(self, arr):
         shape = list(self.meta.shape.numpy()[::-1]) + [-1]
         return torch.swapaxes(arr.reshape(shape), 0, 2)
-
     @property
     def vis_view(self):
         return self.view(self.vis)
@@ -228,7 +238,6 @@ class PhotonLib:
 
         if vis.ndim == 4:
             vis = np.swapaxes(vis, 0, 2).reshape(len(meta), -1)
-
         # TODO check dim(vis) and dim(meta)
 
         print('[PhotonLib] saving to', outpath)

--- a/photonlib/photonlib.py
+++ b/photonlib/photonlib.py
@@ -21,7 +21,7 @@ class PhotonLib:
         eff  : float
             Overall scaling factor for the visibility. Does not do anything if 1.0
         lazy : bool, optional
-            Whether to load the visibility map on demand. Default is False.
+            Whether to lazily load the visibility map. Default is False.
         '''
         self._meta = meta
         self._eff = torch.as_tensor(eff,dtype=torch.float32)

--- a/photonlib/photonlib.py
+++ b/photonlib/photonlib.py
@@ -208,6 +208,7 @@ class PhotonLib:
     def view(self, arr):
         shape = list(self.meta.shape.numpy()[::-1]) + [-1]
         return torch.swapaxes(arr.reshape(shape), 0, 2)
+
     @property
     def vis_view(self):
         return self.view(self.vis)
@@ -238,6 +239,7 @@ class PhotonLib:
 
         if vis.ndim == 4:
             vis = np.swapaxes(vis, 0, 2).reshape(len(meta), -1)
+
         # TODO check dim(vis) and dim(meta)
 
         print('[PhotonLib] saving to', outpath)

--- a/tests/test_LazyTensor.py
+++ b/tests/test_LazyTensor.py
@@ -1,0 +1,122 @@
+import gc
+import h5py
+import numpy as np
+import torch
+
+from photonlib.lazy import LazyTensor
+from tests.fixtures import fake_photon_library
+
+
+def test_lazytensor_from_tensor_cpu():
+    src = torch.arange(20, dtype=torch.float32).reshape(10, 2)
+    lt = LazyTensor(src)
+
+    assert lt.device.type == 'cpu'
+    assert lt.dtype == torch.float32
+    assert len(lt) == 10
+    assert tuple(lt.shape) == (10, 2)
+
+    # indexing and materialize should match source
+    assert torch.allclose(lt[3], src[3])
+    assert torch.allclose(lt[0:4], src[0:4])
+    mat = lt.materialize()
+    assert isinstance(mat, torch.Tensor)
+    assert torch.allclose(mat, src)
+
+    # to on same device returns self
+    lt2 = lt.to('cpu')
+    assert lt2 is lt
+
+
+def test_lazytensor_from_h5_dataset(fake_photon_library):
+    # open file without context manager so LazyTensor manages closing
+    f = h5py.File(fake_photon_library, 'r', swmr=True, libver='latest')
+    ds = f['vis']
+
+    lt = LazyTensor(ds, dtype=torch.float32)
+    assert lt.device.type == 'cpu'
+    assert lt.dtype == torch.float32
+    assert len(lt) == ds.shape[0]
+    assert tuple(lt.shape) == tuple(ds.shape)
+
+    # spot check indexing and slicing
+    assert torch.allclose(lt[0], torch.as_tensor(ds[0], dtype=torch.float32))
+    assert torch.allclose(lt[len(lt)-1], torch.as_tensor(ds[len(lt)-1], dtype=torch.float32))
+
+    sl = slice(1, 5)
+    assert torch.allclose(lt[sl], torch.as_tensor(ds[sl], dtype=torch.float32))
+
+    # materialize should match full dataset
+    mat = lt.materialize()
+    assert isinstance(mat, torch.Tensor)
+    assert torch.allclose(mat, torch.as_tensor(ds[:], dtype=torch.float32))
+
+    # deletion should close the file the dataset came from
+    del lt
+    gc.collect()
+    # file may already be closed by LazyTensor; check "valid" if available
+    try:
+        assert not f.id.valid
+    except Exception:
+        # if attribute access not available, at least ensure operations fail
+        failed = False
+        try:
+            _ = ds.shape  # access should raise if closed
+        except Exception:
+            failed = True
+        assert failed
+
+
+def test_lazytensor_h5_getitem_variants(fake_photon_library):
+    # Exercise various __getitem__ forms against an h5py dataset source
+    f = h5py.File(fake_photon_library, 'r', swmr=True, libver='latest')
+    ds = f['vis']
+    lt = LazyTensor(ds, dtype=torch.float32)
+
+    n = len(lt)
+    # scalar int
+    assert torch.allclose(lt[0], torch.as_tensor(ds[0], dtype=torch.float32))
+
+    # simple slice
+    assert torch.allclose(lt[1:4], torch.as_tensor(ds[1:4], dtype=torch.float32))
+
+    # tuple of slices (rows, cols)
+    assert torch.allclose(
+        lt[1:4, 2:7], torch.as_tensor(ds[1:4, 2:7], dtype=torch.float32)
+    )
+
+    # list of row indices (non-monotonic)
+    rows = [5, 2, 7]
+    lt_rows = lt[rows]
+    ds_rows = torch.stack([torch.as_tensor(ds[i], dtype=torch.float32) for i in rows], dim=0)
+    assert torch.allclose(lt_rows, ds_rows)
+
+    # numpy array of row indices (non-monotonic)
+    np_idx = np.array([3, 1, 6], dtype=np.int64)
+    lt_rows = lt[np_idx]
+    ds_rows = torch.stack([torch.as_tensor(ds[i], dtype=torch.float32) for i in np_idx.tolist()], dim=0)
+    assert torch.allclose(lt_rows, ds_rows)
+
+    # torch tensor of row indices
+    t_idx = torch.tensor([4, 0, 2], dtype=torch.long)
+    lt_rows = lt[t_idx]
+    ds_rows = torch.stack([torch.as_tensor(ds[i], dtype=torch.float32) for i in t_idx.tolist()], dim=0)
+    assert torch.allclose(lt_rows, ds_rows)
+
+    # boolean mask (numpy)
+    mask_np = np.zeros(n, dtype=bool)
+    mask_np[[0, 2, n - 1]] = True
+    lt_rows = lt[mask_np]
+    ds_rows = torch.stack([torch.as_tensor(ds[i], dtype=torch.float32) for i in np.where(mask_np)[0].tolist()], dim=0)
+    assert torch.allclose(lt_rows, ds_rows)
+
+    # boolean mask (torch)
+    mask_t = torch.zeros(n, dtype=torch.bool)
+    mask_t[[1, 3, n - 2]] = True
+    lt_rows = lt[mask_t]
+    ds_rows = torch.stack([torch.as_tensor(ds[i], dtype=torch.float32) for i in torch.nonzero(mask_t, as_tuple=False).flatten().tolist()], dim=0)
+    assert torch.allclose(lt_rows, ds_rows)
+
+    # cleanup
+    del lt
+    f.close()

--- a/tests/test_PhotonLib_lazy.py
+++ b/tests/test_PhotonLib_lazy.py
@@ -1,0 +1,80 @@
+import h5py
+import torch
+import numpy as np
+
+from photonlib import PhotonLib, VoxelMeta
+from photonlib.lazy import LazyTensor
+from tests.fixtures import fake_photon_library, fake_photon_library_ranges as ranges_fixture, num_pmt
+
+
+def test_photonlib_load_lazy_returns_lazytensor(fake_photon_library, num_pmt):
+    plib = PhotonLib.load(fake_photon_library, lazy=True)
+    assert isinstance(plib.vis, LazyTensor)
+
+    with h5py.File(fake_photon_library, 'r') as f:
+        ds = f['vis']
+        assert len(plib) == ds.shape[0]
+        assert tuple(plib.vis.shape) == tuple(ds.shape)
+        assert plib.n_pmts == num_pmt
+
+
+def test_photonlib_lazy_indexing_matches_dataset(fake_photon_library):
+    plib = PhotonLib.load(fake_photon_library, lazy=True)
+
+    # compare a few rows to the dataset directly
+    f = h5py.File(fake_photon_library, 'r', swmr=True, libver='latest')
+    ds = f['vis']
+    for i in [0, len(plib)-1, len(plib)//2]:
+        assert torch.allclose(plib[i], torch.as_tensor(ds[i], dtype=torch.float32))
+
+
+def test_photonlib_visibility_lazy_matches_expected(fake_photon_library, ranges_fixture):
+    # use a few random positions inside the volume; compare to dataset rows
+    plib = PhotonLib.load(fake_photon_library, lazy=True)
+    meta = plib.meta
+
+    tranges = torch.as_tensor(ranges_fixture)
+    # 5 random points inside the ranges
+    torch.manual_seed(0)
+    pos = torch.rand(5, 3) * (tranges[:, 1] - tranges[:, 0]) + tranges[:, 0]
+
+    vox = meta.coord_to_voxel(pos)
+
+    # expected vis by reading dataset rows for those voxels
+    # h5py requires increasing order for fancy indexing; fetch row-by-row
+    with h5py.File(fake_photon_library, 'r') as f:
+        ds = f['vis']
+        vox_np = vox.cpu().numpy().tolist()
+        rows = [torch.as_tensor(ds[i], dtype=torch.float32) for i in vox_np]
+        expected = torch.stack(rows, dim=0)
+
+    out = plib.visibility(pos)
+    assert torch.allclose(out, expected)
+
+
+def test_photonlib_gradx2_lazy_consistency_with_dense(fake_photon_library):
+    # gradx2 uses LazyTensor slicing and arithmetic; compare with dense path
+    plib_lazy = PhotonLib.load(fake_photon_library, lazy=True)
+    plib_dense = PhotonLib.load(fake_photon_library, lazy=False)
+
+    # a couple of random positions
+    torch.manual_seed(1)
+    idx = torch.randint(low=0, high=len(plib_lazy), size=(4,))
+    pos = plib_lazy.meta.voxel_to_coord(idx)
+
+    g_lazy = plib_lazy.gradx2(pos)
+    g_dense = plib_dense.gradx2(pos)
+
+    assert torch.allclose(g_lazy, g_dense)
+
+
+def test_photonlib_to_same_device_lazy_identity(fake_photon_library):
+    # In lazy mode on CPU, to('cpu') should return self
+    plib = PhotonLib.load(fake_photon_library, lazy=True)
+    plib2 = plib.to('cpu')
+    assert plib2 is plib
+    # sanity: visibility still works
+    idx = torch.tensor([0, len(plib)//2])
+    pos = plib.meta.voxel_to_coord(idx)
+    out = plib2.visibility(pos)
+    assert out.shape[0] == 2


### PR DESCRIPTION
This option controls the default behavior of loading the photon library completely into memory. If `lazy=True`, parts of the dataset are loaded as needed. This is helpful for photon libraries that may not completely fit into memory.

The default behavior remains unchanged.